### PR TITLE
Get deck info from server instead of hard-coding in client

### DIFF
--- a/PokeServer/Controllers/DeckController.cs
+++ b/PokeServer/Controllers/DeckController.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
+using PokeServer.Model;
+using System.Text.Json;
+
+namespace PokeServer.Controllers
+{
+    [ApiController]
+    [Route("deck")]
+    public class DeckController : ControllerBase
+    {
+        private readonly ILogger<DeckController> _logger;
+        private readonly IMemoryCache _memoryCache;
+
+        public DeckController(ILogger<DeckController> logger, IMemoryCache memoryCache)
+        {
+            _logger = logger;
+            _memoryCache = memoryCache;
+        }
+
+        [HttpGet]
+        [Route("getalldeckbriefs")]
+        public async Task<List<DeckBrief>> GetAllDeckBriefs()
+        {
+            List<DeckBrief> deckBriefs = new();
+
+
+            using (StreamReader r = new StreamReader("TestData/TestDecks.json"))
+            {
+                string json = r.ReadToEnd();
+                List<Deck> decks = JsonSerializer.Deserialize<List<Deck>>(json);
+                foreach (Deck deck in decks)
+                {
+                    DeckBrief deckBrief = new DeckBrief
+                    {
+                        DeckId = deck.DeckId,
+                        Name = deck.Name,
+                        Description = deck.Description
+                    };
+                    deckBriefs.Add(deckBrief);
+                }
+            }
+            return deckBriefs;
+        }
+    }
+}

--- a/PokeServer/Model/DeckBrief.cs
+++ b/PokeServer/Model/DeckBrief.cs
@@ -1,0 +1,9 @@
+﻿namespace PokeServer.Model
+{
+    public class DeckBrief
+    {
+        public int DeckId { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+    }
+}

--- a/PokeServer/PokeServer.http
+++ b/PokeServer/PokeServer.http
@@ -126,3 +126,7 @@ Content-Type: application/json
 GET {{PokeServer_HostAddress}}/game/getvalidevolutions/{{pokemonName}}
 
 ###
+
+GET {{PokeServer_HostAddress}}/deck/getalldeckbriefs
+
+###


### PR DESCRIPTION
created deck controller, and one endpoint so far, to return all deck summaries (leaving out specific card info)