### PR TITLE
Log hand discard

### DIFF
--- a/PokeServer/Model/Enums.cs
+++ b/PokeServer/Model/Enums.cs
@@ -43,6 +43,8 @@
             CARD_MOVED_TO_DISCARD = 104,
             CARD_MOVED_TO_BENCH = 105,
             CARD_MOVED_TO_ACTIVE = 106,
+            HAND_MOVED_TO_DISCARD = 107,
+            //HAND_MOVED_TO_DECK = 108,
             //CARD_ATTACHED_TO_ACTIVE_POKEMON = 201,
             //CARD_ATTACHED_TO_BENCH_POKEMON = 202,
             //POKEMON_EVOLVED = 301,

--- a/PokeServer/PokeServer.http
+++ b/PokeServer/PokeServer.http
@@ -6,7 +6,7 @@ GET {{PokeServer_HostAddress}}/game/getnewgame/{{DeckId}}
 
 
 ###
-@Guid=552d411f-e1c5-4afd-8c0d-76842fa3d9dc
+@Guid=bbe48b9e-bfcb-40c3-9ae0-03b5a83508e6
 GET {{PokeServer_HostAddress}}/game/checkgameactive/{{guid}}
 
 ###
@@ -194,5 +194,9 @@ Content-Type: application/json
     "attachedCards": [],
     "damageCounters": 0
 }
+
+###
+
+GET {{PokeServer_HostAddress}}/game/getgamehistory/{{guid}}
 
 ###


### PR DESCRIPTION
Switched discard hand method to add game event once for the whole hand discard, instead of one for each card.

Resolve #29